### PR TITLE
shortestpath

### DIFF
--- a/CPP/shortestpath.cpp
+++ b/CPP/shortestpath.cpp
@@ -1,0 +1,56 @@
+
+#include <climits>
+#include <ext/pb_ds/priority_queue.hpp>
+#include <iostream>
+#include <utility>
+#include <vector>
+using namespace std;
+using namespace __gnu_pbds;
+template <class X, class C = greater<X>>
+using heap = __gnu_pbds::priority_queue<X, C>;
+vector<heap<pair<int, int>>::point_iterator> pt;
+vector<int> d;
+vector<vector<pair<int, int>>> g;
+void dijkstra(int s) {
+	fill(d.begin(), d.end(), INT_MAX);
+	d[s] = 0;
+	heap<pair<int, int>> q;
+	pt[s] = q.push(make_pair(d[s], s));
+	while (!q.empty()) {
+		auto v = q.top().second;
+		q.pop();
+		for (auto x : g[v]) {
+			if (d[v] + x.second < d[x.first]) {
+				d[x.first] = d[v] + x.second;
+				if (pt[x.first] != nullptr) {
+					q.modify(pt[x.first], make_pair(d[x.first], x.first));
+				} else {
+					q.push(make_pair(d[x.first], x.first));
+				}
+			}
+		}
+	}
+}
+int main() {
+	ios::sync_with_stdio(0);
+	cin.tie(0);
+	int n, m;
+	cin >> n >> m;
+	d.resize(n);
+	g.resize(n);
+	pt.resize(n);
+	for (int i = 0; i < m; i++) {
+		int x, y, w;
+		cin >> x >> y >> w;
+		x--;
+		y--;
+		g[x].push_back({y, w});
+		g[y].push_back({x, w});
+	}
+	int s;
+	cin >> s;
+	s--;
+	dijkstra(s);
+	for (auto x : d) cout << x << ' ';
+	return 0;
+}


### PR DESCRIPTION
shortest path from one node to another node in an unweighted graph using breadth first search pitch the complexity of this algorithm: o(v+e) complexity of dijkstra algorithm: o(v^2) when unoptimized, or o(v + e log v) when optimized using priority queue. this algorithm is faster than the popular dijkstra algorithm, and is also far simpler, as it only uses a breadth first search in github